### PR TITLE
Add missing resource links for 2vmx1net

### DIFF
--- a/openstack/vmx-topologies/osp-topologies/2vmx1net.env
+++ b/openstack/vmx-topologies/osp-topologies/2vmx1net.env
@@ -35,4 +35,7 @@ resource_registry:
   "OS::Networking::VmxNet": vmx-components/bridges/bridge_wan.yaml
   "OS::Networking::VmxPort": vmx-components/ports/port.yaml
   "OS::Networking::VmxSriovPort": vmx-components/ports/sriov_port.yaml
+  "OS::Networking::VmFixedNet": vmx-components/vms/vm_fixed_net.yaml
   "OS::Networking::VmxPortWithIP": vmx-components/ports/port_with_ip.yaml
+  "OS::Networking::VmxRePfePort": vmx-components/ports/re_pfe_port.yaml
+  "OS::Networking::VmxReIntPort": vmx-components/ports/re_int_port.yaml


### PR DESCRIPTION
These seem to be referred to, but are not linked anywhere, thus
2vmx1net stack creation fails.